### PR TITLE
rpc mempool (--ids-only) and blockcoins return valid json

### DIFF
--- a/cdv/cmds/rpc.py
+++ b/cdv/cmds/rpc.py
@@ -201,9 +201,9 @@ def rpc_addrem_cmd(headerhash: str):
         try:
             node_client: FullNodeRpcClient = await get_client()
             additions, removals = await node_client.get_additions_and_removals(hexstr_to_bytes(headerhash))
-            additions: List[Dict] = json.dumps([rec.to_json_dict() for rec in additions], sort_keys=True, indent=4)
-            removals: List[Dict] = json.dumps([rec.to_json_dict() for rec in removals], sort_keys=True, indent=4)
-            print({"additions": additions, "removals": removals})
+            additions: List[Dict] = [rec.to_json_dict() for rec in additions]
+            removals: List[Dict] = [rec.to_json_dict() for rec in removals]
+            print(json.dumps({"additions": additions, "removals": removals}, sort_keys=True, indent=4))
         finally:
             node_client.close()
             await node_client.await_closed()
@@ -282,7 +282,7 @@ def rpc_mempool_cmd(transaction_id: str, ids_only: bool):
                     items[key.hex()] = b_items[key]
 
             if ids_only:
-                pprint(list(items.keys()))
+                print(json.dumps(list(items.keys()), sort_keys=True, indent=4))
             else:
                 print(json.dumps(items, sort_keys=True, indent=4))
         finally:


### PR DESCRIPTION
Make `cdv rpc mempool --ids-only` & `cdv rpc blockcoins` return valid json.
![cdv-rpc-mempool--ids-only](https://user-images.githubusercontent.com/116863/135105160-06caa110-1e35-4a04-ae66-ef22da611341.png)
![cdv-rpc-blockcoins](https://user-images.githubusercontent.com/116863/135105229-938200d1-856e-4154-b863-6baaa56f8f8f.png)
