### PR TITLE
Cat puzzle hash: referencing tails with default symbols

### DIFF
--- a/cdv/cmds/clsp.py
+++ b/cdv/cmds/clsp.py
@@ -149,9 +149,15 @@ def uncurry_cmd(program: str, treehash: bool, dump: bool):
     ),
 )
 @click.argument("inner_puzzlehash", required=True)
-@click.option("-t", "--tail", "tail_hash", required=True, help="The tail hash of the CAT")
+@click.option("-t", "--tail", "tail_hash", required=True,
+    help="The tail hash of the CAT (hex or one of the standard CAT symbols, e.g. MRMT)")
 def cat_puzzle_hash(inner_puzzlehash: str, tail_hash: str):
     from chia.wallet.puzzles.cat_loader import CAT_MOD
+    from chia.wallet.cat_wallet.cat_constants import DEFAULT_CATS
+
+    default_cats_by_symbols = { cat['symbol']: cat for cat in DEFAULT_CATS.values() }
+    if tail_hash in default_cats_by_symbols:
+      tail_hash = default_cats_by_symbols[tail_hash]['asset_id']
 
     try:
         # User passed in a hex puzzlehash

--- a/cdv/cmds/clsp.py
+++ b/cdv/cmds/clsp.py
@@ -149,15 +149,20 @@ def uncurry_cmd(program: str, treehash: bool, dump: bool):
     ),
 )
 @click.argument("inner_puzzlehash", required=True)
-@click.option("-t", "--tail", "tail_hash", required=True,
-    help="The tail hash of the CAT (hex or one of the standard CAT symbols, e.g. MRMT)")
+@click.option(
+    "-t",
+    "--tail",
+    "tail_hash",
+    required=True,
+    help="The tail hash of the CAT (hex or one of the standard CAT symbols, e.g. MRMT)",
+)
 def cat_puzzle_hash(inner_puzzlehash: str, tail_hash: str):
     from chia.wallet.puzzles.cat_loader import CAT_MOD
     from chia.wallet.cat_wallet.cat_constants import DEFAULT_CATS
 
-    default_cats_by_symbols = { cat['symbol']: cat for cat in DEFAULT_CATS.values() }
+    default_cats_by_symbols = {cat["symbol"]: cat for cat in DEFAULT_CATS.values()}
     if tail_hash in default_cats_by_symbols:
-      tail_hash = default_cats_by_symbols[tail_hash]['asset_id']
+        tail_hash = default_cats_by_symbols[tail_hash]["asset_id"]
 
     try:
         # User passed in a hex puzzlehash

--- a/tests/cmds/test_clsp.py
+++ b/tests/cmds/test_clsp.py
@@ -188,9 +188,19 @@ class TestClspCommands:
             "0x7efa9f202cfd8e174e1376790232f1249e71fbe46dc428f7237a47d871a2b78b",
         ]
         expected_hex = "f529738b9b723fb13bef01c52e9df8a77d54fa770cb0314ae2854f3b1b7bcbf4"
+        args_usds = [
+            "xch16ay8wdjtl8f58gml4vl5jw4vm6ychhu3lk9hddhykhcmt6l6599s9lrvqn",
+            "-t",
+            "USDS"
+        ]
+        expected_usds = "xch1qmm4m495jtq5ypulwp6rsf7c09z78leg4pxlwtty4ke2rptfcmvsd8z7n9"
+
         result_bech32m: Result = runner.invoke(cli, ["clsp", "cat_puzzle_hash"] + args_bech32m)
         assert result_bech32m.exit_code == 0
         assert expected_bech32m in result_bech32m.output
         result_hex: Result = runner.invoke(cli, ["clsp", "cat_puzzle_hash"] + args_hex)
         assert result_hex.exit_code == 0
         assert expected_hex in result_hex.output
+        result_usds: Result = runner.invoke(cli, ["clsp", "cat_puzzle_hash"] + args_usds)
+        assert result_usds.exit_code == 0
+        assert expected_usds in result_usds.output

--- a/tests/cmds/test_clsp.py
+++ b/tests/cmds/test_clsp.py
@@ -188,11 +188,7 @@ class TestClspCommands:
             "0x7efa9f202cfd8e174e1376790232f1249e71fbe46dc428f7237a47d871a2b78b",
         ]
         expected_hex = "f529738b9b723fb13bef01c52e9df8a77d54fa770cb0314ae2854f3b1b7bcbf4"
-        args_usds = [
-            "xch16ay8wdjtl8f58gml4vl5jw4vm6ychhu3lk9hddhykhcmt6l6599s9lrvqn",
-            "-t",
-            "USDS"
-        ]
+        args_usds = ["xch16ay8wdjtl8f58gml4vl5jw4vm6ychhu3lk9hddhykhcmt6l6599s9lrvqn", "-t", "USDS"]
         expected_usds = "xch1qmm4m495jtq5ypulwp6rsf7c09z78leg4pxlwtty4ke2rptfcmvsd8z7n9"
 
         result_bech32m: Result = runner.invoke(cli, ["clsp", "cat_puzzle_hash"] + args_bech32m)


### PR DESCRIPTION
This is a small extension of #29 which enables referencing standard CATs by their symbol names.

Example:

```
$ cdv clsp cat_puzzle_hash xch16ay8wdjtl8f58gml4vl5jw4vm6ychhu3lk9hddhykhcmt6l6599s9lrvqn -t USDS
xch1qmm4m495jtq5ypulwp6rsf7c09z78leg4pxlwtty4ke2rptfcmvsd8z7n9
```