### PR TITLE
Fix plot generation directory when generating plots

### DIFF
--- a/cdv/cmds/sim_utils.py
+++ b/cdv/cmds/sim_utils.py
@@ -103,7 +103,7 @@ def create_chia_directory(
     if not chia_root.is_dir() or not Path(chia_root / "config" / "config.yaml").exists():
         # create chia directories & load config
         chia_init(chia_root, testnet=True, fix_ssl_permissions=True)
-        config = load_config(chia_root, "config.yaml")
+        config: Dict[str, Any] = load_config(chia_root, "config.yaml")
         # apply standard block-tools config.
         config["full_node"]["send_uncompact_interval"] = 0
         config["full_node"]["target_uncompact_proofs"] = 30
@@ -209,8 +209,9 @@ def generate_and_return_fingerprint(mnemonic: Optional[str] = None) -> int:
         sk = Keychain().add_private_key(mnemonic, None)
         fingerprint: int = sk.get_g1().get_fingerprint()
     except KeychainFingerprintExists as e:
-        print(f"Fingerprint: {e.fingerprint} for provided private key already exists.")
-        return e.fingerprint
+        fingerprint = e.fingerprint
+        print(f"Fingerprint: {fingerprint} for provided private key already exists.")
+        return fingerprint
     print(f"Added private key with public key fingerprint {fingerprint}")
     return fingerprint
 

--- a/cdv/cmds/sim_utils.py
+++ b/cdv/cmds/sim_utils.py
@@ -283,6 +283,7 @@ async def generate_plots(config: Dict[str, Any], root_path: Path, fingerprint: i
     from chia.simulator.start_simulator import PLOT_SIZE, PLOTS
 
     farming_puzzle_hash = decode_puzzle_hash(config["simulator"]["farming_address"])
+    os.environ["CHIA_ROOT"] = str(root_path)  # change env variable, to make it match what the daemon would set it to
 
     # create block tools and use local keychain
     bt = BlockTools(

--- a/cdv/test/__init__.py
+++ b/cdv/test/__init__.py
@@ -327,7 +327,7 @@ class Wallet:
         # We need the final coin to know what the announced coin name will be.
         final_coin = CoinWrapper(
             coins[-1].name(),
-            uint64(sum(map(lambda x: x.amount, coins))),
+            uint64(sum([c.amount for c in coins])),
             self.puzzle,
         )
 
@@ -476,7 +476,7 @@ class Wallet:
     # Balance of wallet
     def balance(self) -> uint64:
         """Return the actor's balance in standard coins as we understand it"""
-        return uint64(sum(map(lambda x: x.amount, self.usable_coins.values())))
+        return uint64(sum([c.amount for c in self.usable_coins.values()]))
 
     # Spend a coin, probably a smart coin.
     # Allows the user to specify the arguments for the puzzle solution.

--- a/cdv/test/__init__.py
+++ b/cdv/test/__init__.py
@@ -327,7 +327,7 @@ class Wallet:
         # We need the final coin to know what the announced coin name will be.
         final_coin = CoinWrapper(
             coins[-1].name(),
-            uint64(sum([c.amount for c in coins])),
+            uint64(sum(c.amount for c in coins)),
             self.puzzle,
         )
 
@@ -476,7 +476,7 @@ class Wallet:
     # Balance of wallet
     def balance(self) -> uint64:
         """Return the actor's balance in standard coins as we understand it"""
-        return uint64(sum([c.amount for c in self.usable_coins.values()]))
+        return uint64(sum(c.amount for c in self.usable_coins.values()))
 
     # Spend a coin, probably a smart coin.
     # Allows the user to specify the arguments for the puzzle solution.


### PR DESCRIPTION
When the daemon starts any process its chia_dir environment variable is already overriden to whatever the dir is set to, and this is passed to all child processes, this change basically does the same thing to block tools when we pre create the plots.