### PR TITLE
SpendBundle.debug does prints internally and returns None

### DIFF
--- a/cdv/cmds/chia_inspect.py
+++ b/cdv/cmds/chia_inspect.py
@@ -413,7 +413,7 @@ def do_inspect_spend_bundle_cmd(
                     "GENESIS_CHALLENGE"
                 ]
                 for bundle in spend_bundle_objs:
-                    print(bundle.debug(agg_sig_additional_data=hexstr_to_bytes(genesis_challenge)))
+                    bundle.debug(agg_sig_additional_data=hexstr_to_bytes(genesis_challenge))
             if kwargs["signable_data"]:
                 print("")
                 print("Public Key/Message Pairs")


### PR DESCRIPTION
Minor fix up - SpendBundle.debug returns None and does prints internally