### PR TITLE
Update test-blockchain-main.yml to add nightly

### DIFF
--- a/.github/workflows/test-blockchain-main.yml
+++ b/.github/workflows/test-blockchain-main.yml
@@ -1,4 +1,4 @@
-name: Test against chia-blockchain main
+name: Test against chia-blockchain main and nightly
 
 on:
   workflow_dispatch:
@@ -10,6 +10,8 @@ on:
   pull_request:
     branches:
       - '**'
+  schedule:
+    - cron: "0 11 * * *"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}--${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/long_lived/')) && github.sha || '' }}


### PR DESCRIPTION
Note that running a workflow_dispatch already uncovered an issue:


```
tests/cmds/test_inspect.py:371: AssertionError
============================== slowest durations ===============================
1.11s call     tests/cmds/test_clsp.py::TestClspCommands::test_build
0.98s call     tests/cmds/test_inspect.py::TestInspectCommands::test_spendbundles
0.17s call     tests/cmds/test_clsp.py::TestClspCommands::test_treehash
0.15s call     cdv/examples/tests/test_piggybank.py::TestStandardTransaction::test_piggybank_contribution
0.13s call     cdv/examples/tests/test_piggybank.py::TestStandardTransaction::test_piggybank_completion
0.10s call     cdv/examples/tests/test_piggybank.py::TestStandardTransaction::test_piggybank_stealing
0.07s setup    cdv/examples/tests/test_piggybank.py::TestStandardTransaction::test_piggybank_completion
0.05s setup    cdv/examples/tests/test_piggybank.py::TestStandardTransaction::test_piggybank_stealing
0.05s call     tests/cmds/test_clsp.py::TestClspCommands::test_cat_puzzle_hash
0.05s setup    tests/test_skeleton.py::TestSomething::test_something
0.05s call     tests/cmds/test_inspect.py::TestInspectCommands::test_any
0.04s setup    cdv/examples/tests/test_piggybank.py::TestStandardTransaction::test_piggybank_contribution
0.03s call     tests/cmds/test_clsp.py::TestClspCommands::test_curry
0.01s call     tests/cmds/test_inspect.py::TestInspectCommands::test_spends
0.01s call     tests/cmds/test_clsp.py::TestClspCommands::test_uncurry
0.01s call     tests/cmds/test_inspect.py::TestInspectCommands::test_signatures
0.01s call     tests/cmds/test_inspect.py::TestInspectCommands::test_coinrecords
(49 durations < 0.005s hidden.  Use -vv to show these durations.)
=========================== short test summary info ============================
FAILED tests/cmds/test_inspect.py::TestInspectCommands::test_keys - assert 1 == 0
 +  where 1 = <Result ValueError("'chia' is not in the mnemonic dictionary; may be misspelled")>.exit_code
========================= 1 failed, 21 passed in 4.20s =========================
Error: Process completed with exit code 1.
```
https://github.com/Chia-Network/chia-dev-tools/actions/runs/6725284407/job/18279329999#step:4:369