### PR TITLE
update chia-blockchain, use old sign_coin_spends from chia-blockchain

### DIFF
--- a/cdv/cmds/chia_inspect.py
+++ b/cdv/cmds/chia_inspect.py
@@ -170,7 +170,8 @@ def inspect_any_cmd(ctx: click.Context, objects: Tuple[str]):
             do_inspect_spend_bundle_cmd(ctx, [obj])
         elif type(obj) == CoinRecord:  # type: ignore[comparison-overlap]
             do_inspect_coin_record_cmd(ctx, [obj])
-        elif type(obj) == Program:
+        elif type(obj) == Program:  # type: ignore[comparison-overlap]
+            assert isinstance(obj, Program)
             do_inspect_program_cmd(ctx, [obj])
         elif type(obj) == G1Element:  # type: ignore[comparison-overlap]
             do_inspect_keys_cmd(ctx, public_key=obj)
@@ -427,7 +428,7 @@ def do_inspect_spend_bundle_cmd(
                     "GENESIS_CHALLENGE"
                 ]
                 for bundle in spend_bundle_objs:
-                    bundle.debug(agg_sig_additional_data=hexstr_to_bytes(genesis_challenge))
+                    bundle.debug(agg_sig_additional_data=bytes32(hexstr_to_bytes(genesis_challenge)))
             if kwargs["signable_data"]:
                 print("")
                 print("Public Key/Message Pairs")
@@ -439,7 +440,7 @@ def do_inspect_spend_bundle_cmd(
                             coin_spend.puzzle_reveal.to_program(), coin_spend.solution.to_program(), INFINITE_COST
                         )
                         if conditions_dict is None:
-                            print(f"Generating conditions failed, con:{conditions_dict}")
+                            print(f"Generating conditions failed, con: {conditions_dict}")
                         else:
                             config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
                             genesis_challenge = config["network_overrides"]["constants"][kwargs["network"]][
@@ -456,7 +457,7 @@ def do_inspect_spend_bundle_cmd(
                                     pkm_dict[str(pk)] = [msg]
                 # This very deliberately prints identical messages multiple times
                 for pk_str, msgs in pkm_dict.items():
-                    print(f"{pk_str}:")
+                    print(f"{pk_str}: ")
                     for msg in msgs:
                         print(f"\t- {msg.hex()}")
 

--- a/cdv/cmds/clsp.py
+++ b/cdv/cmds/clsp.py
@@ -9,7 +9,7 @@ import click
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
-from clvm_tools.binutils import assemble, disassemble
+from clvm_tools.binutils import SExp, assemble, disassemble
 
 from cdv.cmds.util import append_include, parse_program
 from cdv.util.load_clvm import compile_clvm
@@ -101,7 +101,7 @@ def treehash_cmd(program: str, include: Tuple[str]):
 )
 def curry_cmd(program: str, args: Tuple[str], treehash: bool, dump: bool, include: Tuple[str]):
     prog: Program = parse_program(program, include)
-    curry_args: List[Program] = [assemble(arg) for arg in args]
+    curry_args: List[SExp] = [assemble(arg) for arg in args]
 
     prog_final: Program = prog.curry(*curry_args)
     if treehash:

--- a/cdv/test/__init__.py
+++ b/cdv/test/__init__.py
@@ -25,10 +25,10 @@ from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (  # standa
     calculate_synthetic_secret_key,
     puzzle_for_pk,
 )
-from chia.wallet.sign_coin_spends import sign_coin_spends
 from chia_rs import AugSchemeMPL, G1Element, G2Element, PrivateKey
 
 from cdv.util.keys import private_key_for_index, public_key_for_index
+from cdv.util.sign_coin_spends import sign_coin_spends
 
 duration_div = 86400.0
 block_time = (600.0 / 32.0) / duration_div
@@ -94,7 +94,7 @@ class CoinWrapper:
         delegated_puzzle_solution = Program.to((1, conditions))
         solution = Program.to([[], delegated_puzzle_solution, []])
 
-        coin_spend_object = CoinSpend(
+        coin_spend_object = make_spend(
             self.coin,
             self.puzzle(),
             solution,
@@ -216,7 +216,7 @@ class Wallet:
         }
 
     def __repr__(self) -> str:
-        return f"<Wallet(name={self.name},puzzle_hash={self.puzzle_hash},pk={self.pk_})>"
+        return f"<Wallet(name={self.name}, puzzle_hash={self.puzzle_hash}, pk={self.pk_})>"
 
     # Wallet RPC methods
     async def get_public_keys(self):

--- a/cdv/util/sign_coin_spends.py
+++ b/cdv/util/sign_coin_spends.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any, Callable, List
+
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.coin_spend import CoinSpend
+from chia.types.spend_bundle import SpendBundle
+from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_for_conditions_dict
+from chia_rs import AugSchemeMPL, G1Element, G2Element
+
+
+async def sign_coin_spends(
+    coin_spends: List[CoinSpend],
+    secret_key_for_public_key_f: Any,  # Potentially awaitable function from G1Element => Optional[PrivateKey]
+    secret_key_for_puzzle_hash: Any,  # Potentially awaitable function from bytes32 => Optional[PrivateKey]
+    additional_data: bytes,
+    max_cost: int,
+    potential_derivation_functions: List[Callable[[G1Element], bytes32]],
+) -> SpendBundle:
+    """
+    Sign_coin_spends runs the puzzle code with the given argument and searches the
+    result for an AGG_SIG_ME condition, which it attempts to sign by requesting a
+    matching PrivateKey corresponding with the given G1Element (public key) specified
+    in the resulting condition output.
+    It's important to note that as mentioned in the documentation about the standard
+    spend that the public key presented to the secret_key_for_public_key_f function
+    provided to sign_coin_spends must be prepared to do the key derivations required
+    by the coin types it's allowed to spend (at least the derivation of the standard
+    spend as done by calculate_synthetic_secret_key with DEFAULT_PUZZLE_HASH).
+    If a coin performed a different key derivation, the pk presented to this function
+    would be similarly alien, and would need to be tried against the first stage
+    derived keys (those returned by master_sk_to_wallet_sk from the ['sk'] member of
+    wallet rpc's get_private_key method).
+    """
+    signatures: List[G2Element] = []
+    pk_list: List[G1Element] = []
+    msg_list: List[bytes] = []
+    for coin_spend in coin_spends:
+        # Get AGG_SIG conditions
+        conditions_dict = conditions_dict_for_solution(coin_spend.puzzle_reveal, coin_spend.solution, max_cost)
+        # Create signature
+        for pk, msg in pkm_pairs_for_conditions_dict(conditions_dict, coin_spend.coin, additional_data):
+            pk_list.append(pk)
+            msg_list.append(msg)
+            if inspect.iscoroutinefunction(secret_key_for_public_key_f):
+                secret_key = await secret_key_for_public_key_f(pk)
+            else:
+                secret_key = secret_key_for_public_key_f(pk)
+            if secret_key is None or secret_key.get_g1() != pk:
+                for derive in potential_derivation_functions:
+                    if inspect.iscoroutinefunction(secret_key_for_puzzle_hash):
+                        secret_key = await secret_key_for_puzzle_hash(derive(pk))
+                    else:
+                        secret_key = secret_key_for_puzzle_hash(derive(pk))
+                    if secret_key is not None and secret_key.get_g1() == pk:
+                        break
+                else:
+                    raise ValueError(f"no secret key for {pk}")
+            signature = AugSchemeMPL.sign(secret_key, msg)
+            signatures.append(signature)
+
+    # Aggregate signatures
+    aggsig = AugSchemeMPL.aggregate(signatures)
+    return SpendBundle(coin_spends, aggsig)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ dependencies = [
     "pytest-asyncio",
     "pytimeparse",
     "anyio",
-    "chia-blockchain==2.3.1",
+    "chia-blockchain==2.4.0",
 ]
 
 dev_dependencies = [


### PR DESCRIPTION
This repo uses `sign_coin_spends` in the tests which was removed from chia-blockchain. For simplicity I've pulled the signing function in, and will need to create a separate PR to update the repo to use new wallet signing methods