### PR TITLE
types-pkg-resources -> types-setuptools; fixup activated script

### DIFF
--- a/activated.py
+++ b/activated.py
@@ -7,7 +7,7 @@ import pathlib
 import subprocess
 import sys
 
-here = pathlib.Path(__file__).parent
+here = pathlib.Path(__file__).parent.absolute()
 
 
 def main(*args: str) -> int:
@@ -20,7 +20,7 @@ def main(*args: str) -> int:
         command = ["powershell", os.fspath(here.joinpath(script)), *args]
     else:
         script = "activated.sh"
-        command = [os.fspath(here.joinpath(script)), *args]
+        command = ["sh", os.fspath(here.joinpath(script)), *args]
 
     completed_process = subprocess.run(command)
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ dev_dependencies = [
     "types-aiofiles",
     "types-click",
     "types-cryptography",
-    "types-pkg_resources",
+    "types-setuptools",
     "types-pyyaml",
     "types-setuptools",
     "isort",


### PR DESCRIPTION
Fixup some issues with dev dependencies and pre-commit

types-pkg-resources was yanked and replaced with types-setuptools
update activated.py script with the same version from chia-blockchain