### PR TITLE
use 3.10 for pypi publish

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -25,10 +25,10 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.10"
 
     - name: Install build tools (pep517 compatible)
       run: >-


### PR DESCRIPTION
Switch from 3.8 to using python 3.10 for pypi workflow