### PR TITLE
Update to chia-blockchain 2.5.3 along with needed import changes 

### DIFF
--- a/cdv/cmds/chia_inspect.py
+++ b/cdv/cmds/chia_inspect.py
@@ -14,7 +14,6 @@ from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.bundle_tools import simple_solution_generator
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import INFINITE_COST, Program
-from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.generator_types import BlockGenerator
@@ -22,7 +21,6 @@ from chia.util.byte_types import hexstr_to_bytes
 from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_for_conditions_dict
 from chia.util.config import load_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
-from chia.util.ints import uint32, uint64
 from chia.util.keychain import bytes_to_mnemonic, mnemonic_to_seed
 from chia.wallet.derive_keys import _derive_path
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
@@ -32,6 +30,8 @@ from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
 )
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 from chia_rs import AugSchemeMPL, G1Element, G2Element, PrivateKey
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint32, uint64
 
 from cdv.cmds.util import parse_program
 

--- a/cdv/cmds/cli.py
+++ b/cdv/cmds/cli.py
@@ -6,9 +6,9 @@ from pathlib import Path
 
 import click
 import pytest
-from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.util.hash import std_hash
+from chia_rs.sized_bytes import bytes32
 
 from cdv import __version__
 from cdv.cmds.chia_inspect import inspect_cmd

--- a/cdv/cmds/clsp.py
+++ b/cdv/cmds/clsp.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 import click
 from chia.types.blockchain_format.program import Program
-from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
+from chia_rs.sized_bytes import bytes32
 from clvm_tools.binutils import SExp, assemble, disassemble
 
 from cdv.cmds.util import append_include, parse_program

--- a/cdv/cmds/rpc.py
+++ b/cdv/cmds/rpc.py
@@ -11,7 +11,6 @@ from chia.cmds.cmds_util import format_bytes
 from chia.consensus.block_record import BlockRecord
 from chia.rpc.full_node_rpc_client import FullNodeRpcClient
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend
 from chia.types.full_block import FullBlock
@@ -19,7 +18,8 @@ from chia.types.unfinished_header_block import UnfinishedHeaderBlock
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.config import load_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
-from chia.util.ints import uint16, uint64
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint16, uint64
 
 from cdv.cmds.chia_inspect import do_inspect_spend_bundle_cmd
 from cdv.cmds.util import fake_context

--- a/cdv/examples/drivers/piggybank_drivers.py
+++ b/cdv/examples/drivers/piggybank_drivers.py
@@ -6,8 +6,8 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.util.hash import std_hash
-from chia_rs.sized_ints import uint64
 from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint64
 from clvm.casts import int_to_bytes
 
 import cdv.clibs as std_lib

--- a/cdv/examples/drivers/piggybank_drivers.py
+++ b/cdv/examples/drivers/piggybank_drivers.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
-from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.util.hash import std_hash
 from chia.util.ints import uint64
+from chia_rs.sized_bytes import bytes32
 from clvm.casts import int_to_bytes
 
 import cdv.clibs as std_lib

--- a/cdv/examples/drivers/piggybank_drivers.py
+++ b/cdv/examples/drivers/piggybank_drivers.py
@@ -6,7 +6,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.util.hash import std_hash
-from chia.util.ints import uint64
+from chia_rs.sized_ints import uint64
 from chia_rs.sized_bytes import bytes32
 from clvm.casts import int_to_bytes
 

--- a/cdv/examples/tests/test_piggybank.py
+++ b/cdv/examples/tests/test_piggybank.py
@@ -7,7 +7,7 @@ import pytest_asyncio
 from chia.types.blockchain_format.coin import Coin
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
-from chia.util.ints import uint64
+from chia_rs.sized_ints import uint64
 
 from cdv.examples.drivers.piggybank_drivers import (
     create_piggybank_puzzle,

--- a/cdv/test/__init__.py
+++ b/cdv/test/__init__.py
@@ -13,13 +13,11 @@ from chia._tests.util.spend_sim import SimClient, SpendSim
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
-from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.spend_bundle import SpendBundle
 from chia.util.condition_tools import ConditionOpcode
 from chia.util.hash import std_hash
-from chia.util.ints import uint32, uint64
 from chia.wallet.derive_keys import master_sk_to_wallet_sk
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (  # standard_transaction
     DEFAULT_HIDDEN_PUZZLE_HASH,
@@ -27,6 +25,8 @@ from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (  # standa
     puzzle_for_pk,
 )
 from chia_rs import AugSchemeMPL, G1Element, G2Element, PrivateKey
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint32, uint64
 
 from cdv.util.keys import private_key_for_index, public_key_for_index
 from cdv.util.sign_coin_spends import sign_coin_spends

--- a/cdv/util/sign_coin_spends.py
+++ b/cdv/util/sign_coin_spends.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import inspect
 from typing import Any, Callable
 
-from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
 from chia.types.spend_bundle import SpendBundle
 from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_for_conditions_dict
 from chia_rs import AugSchemeMPL, G1Element, G2Element
+from chia_rs.sized_bytes import bytes32
 
 
 async def sign_coin_spends(

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ dependencies = [
     "pytest-asyncio",
     "pytimeparse",
     "anyio",
-    "chia-blockchain==2.5.2",
+    "chia-rs==0.21.2",
+    "chia-blockchain==2.5.3",
 ]
 
 dev_dependencies = [


### PR DESCRIPTION
Uses imports from chia_rs for `sized_bytes` and `sized_ints` - also locks `chia_rs` to 0.21.2 as 0.22 is incompatible and we didn't quite do the versioning probably for that to just work, to need to manually specify it.